### PR TITLE
Kate support.

### DIFF
--- a/AnyKernel2/anykernel.sh
+++ b/AnyKernel2/anykernel.sh
@@ -12,7 +12,7 @@ do.cleanuponabort=0
 device.name1=kenzo
 device.name2=o
 device.name3=s
-device.name4=
+device.name4=kate
 device.name5=
 '; } # end properties
 


### PR DESCRIPTION
With the actual status of anykernel.sh, kate users can't flash the standalone kernel in twrp, tested with official twrp 3.2.3-0. 

twrp log: 

Checking device...
 
Unsupported device. Aborting...
Updater process ended with ERROR: 1
I:Install took 1 second(s).
Error installing zip file '/sdcard/Escrima-X26-Kamui-LightningBlade-PurpleLightning-kenzo-12122018.zip'

Complete log: https://del.dog/goxeliwihi.sql

With this change the flashing process works without any issues.